### PR TITLE
Add a read message Queue

### DIFF
--- a/ConsoleTests/Program.cs
+++ b/ConsoleTests/Program.cs
@@ -16,7 +16,7 @@ TcpConnection myConnection = new TcpConnection("127.0.0.1", 33333);
 myConnection.MessageHandler = MessageHandler;
 
 TcpConnection serverSideConnection = acceptClient.Result; 
-serverSideConnection.WritePacket(Encoding.ASCII.GetBytes("Hello, world!"));
+serverSideConnection.WriteMessage(Encoding.ASCII.GetBytes("Hello, world!"));
 
 Console.ReadKey(true);
 

--- a/LightBlueFox.Networking/Connection.cs
+++ b/LightBlueFox.Networking/Connection.cs
@@ -1,14 +1,28 @@
 ﻿using System.Collections.Concurrent;
+using System.Diagnostics;
 
 namespace LightBlueFox.Networking
 {
     // This describes any connection between two programs, be it over the internet or whatever other communication media.
     public abstract class Connection
     {
+
+        private MessageHandler? _handler;
         /// <summary>
         /// A method which handles any incoming packets
         /// </summary>
-        public MessageHandler? MessageHandler { get; set; }
+        public MessageHandler? MessageHandler 
+        {
+            get
+            {
+                return _handler;
+            }
+            set
+            {
+                ReadQueue.WorkOnQueue = value != null;
+                _handler = value;
+            }
+        }
 
         /// <summary>
         /// Gets called when the connection is terminated. An exception is provided as the reason for the disconnection.
@@ -26,6 +40,43 @@ namespace LightBlueFox.Networking
         protected void CallConnectionClosed(Exception? ex)
         {
             Task.Run(() => ConnectionDisconnected?.Invoke(this, ex));
+        }
+
+        #region Message Queuing
+
+        public bool KeepMessagesInOrder = true;
+
+
+        private void handleReadQueue(MessageStoreHandle msg)
+        {
+            var callHandler = () =>
+            {
+                MessageHandler?.Invoke(msg.Buffer.Span, new(this));
+                msg.FinishedHandling?.Invoke(msg.Buffer, this);
+            };
+
+            if (KeepMessagesInOrder) callHandler();
+            else Task.Run(callHandler);
+        }
+
+        private MessageQueue ReadQueue;
+
+
+        #region Queue Worker
+
+        #endregion
+
+        protected void MessageReceived(ReadOnlyMemory<byte> message, MessageReleasedHandler? finished)
+        {
+            if (MessageHandler == null || KeepMessagesInOrder) ReadQueue.Add(new(message, finished));
+            else Task.Run(() => { MessageHandler.Invoke(message.Span, new(this)); finished?.Invoke(message, this); });
+        }
+
+        #endregion
+
+        public Connection()
+        {
+            ReadQueue = new MessageQueue(handleReadQueue);
         }
     }
     /// <summary>

--- a/LightBlueFox.Networking/Connection.cs
+++ b/LightBlueFox.Networking/Connection.cs
@@ -19,7 +19,7 @@ namespace LightBlueFox.Networking
         /// Sends a packet to the program at the other side.
         /// </summary>
         /// <param name="Packet">Just the packet data, no size prefix required.</param>
-        public abstract void WritePacket(ReadOnlyMemory<byte> Packet);
+        public abstract void WriteMessage(ReadOnlyMemory<byte> Packet);
 
         public abstract void CloseConnection();
 

--- a/LightBlueFox.Networking/MessageQueue.cs
+++ b/LightBlueFox.Networking/MessageQueue.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LightBlueFox.Networking
+{
+
+    public delegate void MessageQueueActionHandler(MessageStoreHandle storedMessage);
+    internal class MessageQueue
+    {
+        public MessageQueueActionHandler? QueueAction;
+
+
+        private BlockingCollection<MessageStoreHandle> storedMessages = new();
+
+        private Task? QueueWorkerTask = null;
+        private CancellationTokenSource stopTakingMessages = new();
+        private void QueueWorker()
+        {
+            var token = stopTakingMessages.Token;
+            while (!token.IsCancellationRequested)
+            {
+                MessageStoreHandle msg;
+                try
+                {
+                    msg = storedMessages.Take(token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                QueueAction?.Invoke(msg);
+
+            }
+            QueueWorkerTask = null;
+
+        }
+
+        public bool WorkOnQueue
+        {
+            get
+            {
+                return QueueWorkerTask != null;
+            }
+            set
+            {
+                if (value && QueueWorkerTask == null) QueueWorkerTask = Task.Run(QueueWorker);
+                else if(!value && QueueWorkerTask != null) stopTakingMessages.Cancel();
+            }
+        }
+
+        public MessageQueue(MessageQueueActionHandler queueAction)
+        {
+            this.QueueAction = queueAction;
+        }
+
+        public void Add(MessageStoreHandle message)
+        {
+            storedMessages.Add(message);
+        }
+    }
+}

--- a/LightBlueFox.Networking/MessageStoreHandle.cs
+++ b/LightBlueFox.Networking/MessageStoreHandle.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LightBlueFox.Networking
+{
+    public delegate void MessageReleasedHandler(ReadOnlyMemory<byte> message, Connection c);
+    public struct MessageStoreHandle
+    {
+        public ReadOnlyMemory<byte> Buffer;
+        public MessageReleasedHandler? FinishedHandling;
+        public MessageStoreHandle(ReadOnlyMemory<byte> buffer, MessageReleasedHandler? fh)
+        {
+            Buffer = buffer;
+            FinishedHandling = fh;
+        }
+    }
+    
+}

--- a/LightBlueFox.Networking/NetworkConnection.cs
+++ b/LightBlueFox.Networking/NetworkConnection.cs
@@ -138,7 +138,7 @@ namespace LightBlueFox.Networking
         /// <summary>
         /// Ask the connection to write a new packet to the socket.
         /// </summary>
-        public override void WritePacket(ReadOnlyMemory<byte> Packet)
+        public override void WriteMessage(ReadOnlyMemory<byte> Packet)
         {
             if (IsClosed) throw new InvalidOperationException("Socket is closed.");
             if (Protocol == Protocol.UDP && Packet.Length + 4 > 59900) throw new ArgumentException("A udp message may not be over 59900 bytes in length!");

--- a/LightBlueFox.Networking/UdpConnection.cs
+++ b/LightBlueFox.Networking/UdpConnection.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -19,77 +20,14 @@ namespace LightBlueFox.Networking
         }
 
         /// <summary>
-        /// If true; waits for one message to finish processing before the next one is passed to the handler
-        /// </summary>
-        public override bool KeepMessagesInOrder { get; set; }
-
-        /// <summary>
-        /// Class-Internal representation of one or more messages sent in one datagram
-        /// </summary>
-        private class UdpMultiMessage
-        {
-            public static ArrayPool<byte> bufferPool = ArrayPool<byte>.Shared;
-
-            public UdpMultiMessage(int messages, byte[] buffer)
-            {
-                _messages = messages; bufferToReturn = buffer;
-            }
-            /// <summary>
-            /// The number of messages still not handled from this datagram.
-            /// </summary>
-            private int _messages;
-
-            /// <summary>
-            /// Makes sure buffer is returned as soon as all messages are handled.
-            /// </summary>
-            public int MessagesRemaining { get { return _messages; } set { _messages = value; if (_messages <= 0) bufferPool.Return(bufferToReturn); } }
-            private byte[] bufferToReturn;
-        }
-
-        private async Task Deconstruct(byte[] datagram, int length, bool mode, UDPPacketArgs args)
-        {
-            await Task.Run(() => {
-                int index = 0;
-                int payload_len;
-                
-
-                UdpMultiMessage up = new UdpMultiMessage(0, datagram);
-
-                while (index < length)
-                {
-                    payload_len = BinaryPrimitives.ReadInt32LittleEndian(new ReadOnlySpan<byte>(datagram, index, 4));
-                    index += 4;
-
-                    if (payload_len > 0)
-                    {
-                        ReadOnlyMemory<byte> payload = new ReadOnlyMemory<byte>(datagram, index, payload_len);
-                        //Need to check mode instead of KeepMessagesInOrder since that could have changed between some of the packets
-                        if (mode)
-                        {
-                            MessageHandler?.Invoke(payload.Span, args);
-                        }
-                        else
-                        {
-                            up.MessagesRemaining += 1;
-                            Task.Run(() => { MessageHandler?.Invoke(payload.Span, args); up.MessagesRemaining--; });
-                        }
-
-                        index += payload_len;
-                    }
-                }
-            });
-        }
-
-        /// <summary>
-        /// This buffer is used when messages are kept in order (since the buffer can be overwritten once a message has been handled)
-        /// If <see cref="KeepMessagesInOrder"/> is false, buffers are rented from an arraypool.
+        ///
         /// </summary>
         private byte[] syncBuffer = new byte[60000];
+        private static ArrayPool<byte> messageBufferPool = ArrayPool<byte>.Shared;
         protected async override void StartListening()
         {
             await Task.Run(() => {
                 bool mode = KeepMessagesInOrder;
-                byte[] buffer = KeepMessagesInOrder ? syncBuffer : UdpMultiMessage.bufferPool.Rent(60000);
                 while (true)
                 {
                     
@@ -97,17 +35,16 @@ namespace LightBlueFox.Networking
                     {
                         
                         EndPoint ep = RemoteEndpoint ?? new IPEndPoint(IPAddress.Any, 0);
+                        
                         int len = Socket.ReceiveFrom(syncBuffer, ref ep);
-                        
-                        
-                        if (RemoteEndpoint == null || RemoteEndpoint == ep)
-                        {
-                            if (len > 0) Deconstruct(syncBuffer, len, mode, new UDPPacketArgs(this, RemoteEndpoint != null, ep)).Wait();
-                        }
+                        if (len == 0) continue;
+                        if (RemoteEndpoint != null && RemoteEndpoint != ep) continue;
 
 
-                        mode = KeepMessagesInOrder;
-                        if (!mode && len > 0) buffer = UdpMultiMessage.bufferPool.Rent(60000);
+                        byte[] newBuff = messageBufferPool.Rent(len);
+                        Array.Copy(syncBuffer, 0, newBuff, 0, len);
+
+                        MessageReceived(new ReadOnlyMemory<byte>(newBuff, 0, len), (b, c) => { messageBufferPool.Return(newBuff); });
                     }
                     catch (Exception ex) when (ex is SocketException || ex is ObjectDisposedException)
                     {
@@ -120,14 +57,14 @@ namespace LightBlueFox.Networking
         }
 
         /// <summary>
-        /// Writes one or more messages as a single datagram
+        /// Writes a single datagram
         /// </summary>
-        protected override void WriteToSocket(byte[] data)
+        protected override void WriteToSocket(ReadOnlyMemory<byte> data)
         {
             try
             {
                 if (RemoteEndpoint == null) throw new InvalidOperationException("Cannot use Write without knowing the recipient! Either set a default recipient, or use WriteTo!");
-                Socket.SendTo(data, RemoteEndpoint);
+                Socket.SendTo(data.Span, RemoteEndpoint);
             }
             catch (Exception ex) when (ex is SocketException || ex is ObjectDisposedException)
             {

--- a/NetworkTests/ConnectionTest.cs
+++ b/NetworkTests/ConnectionTest.cs
@@ -31,7 +31,7 @@ namespace NetworkTests
             receiver.MessageHandler = (e, args) => { 
                 tcs.SetResult(e.ToArray());
             };
-            sender.WritePacket(d[0].ToArray());
+            sender.WriteMessage(d[0].ToArray());
             Assert.IsTrue(Helpers.Compare(tcs.Task.GetAwaiter().GetResult(), d[0].ToArray()));
             sender.CloseConnection();
             
@@ -39,6 +39,7 @@ namespace NetworkTests
         [TestMethod]
         public void TestTcpConnection_MultiPacket()
         {
+
             (NetworkConnection sender, NetworkConnection receiver) = Helpers.GetTcpConnections(12312);
             (receiver as TcpConnection ?? throw new Exception()).KeepMessagesInOrder = true;
 
@@ -47,15 +48,17 @@ namespace NetworkTests
             TaskCompletionSource<List<byte>[]> tcs = new TaskCompletionSource<List<byte>[]>();
 
             List<List<byte>> receivedPackets = new List<List<byte>>();
+            
+            foreach (var item in d)
+            {
+                sender.WriteMessage(item.ToArray());
+            }
             receiver.MessageHandler = (e, args) =>
             {
                 receivedPackets.Add(e.ToArray().ToList());
-                if(receivedPackets.Count == d.Length) tcs.SetResult(receivedPackets.ToArray());
+                if (receivedPackets.Count == d.Length) tcs.SetResult(receivedPackets.ToArray());
             };
-            foreach (var item in d)
-            {
-                sender.WritePacket(item.ToArray());
-            }
+
             Assert.IsTrue(Helpers.CompareL(tcs.Task.GetAwaiter().GetResult(), d));
             sender.CloseConnection();
         }
@@ -74,7 +77,7 @@ namespace NetworkTests
             {
                 tcs.SetResult(e.ToArray());
             };
-            sender.WritePacket(d[0].ToArray());
+            sender.WriteMessage(d[0].ToArray());
             Assert.IsTrue(Helpers.Compare(tcs.Task.GetAwaiter().GetResult(), d[0].ToArray()));
             sender.CloseConnection();
         }
@@ -97,7 +100,7 @@ namespace NetworkTests
             };
             foreach (var item in d)
             {
-                sender.WritePacket(item.ToArray());
+                sender.WriteMessage(item.ToArray());
             }
             sender.CloseConnection();
         }

--- a/NetworkTests/NetworkTests.csproj
+++ b/NetworkTests/NetworkTests.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BasicMessageManager\BasicMessageManager.csproj" />
     <ProjectReference Include="..\LightBlueFox.Networking\LightBlueFox.Networking.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The previous solution had a number of issues and incosistencies, such as:
* Loss of any messages received before the message handler is set
* Inconsistent code and code duplication (such as the KeepMessagesInOrder flag)
* Lifetime of message buffers is difficult to control

Now, all messages received by any type of connection are passed on to the `Connection` base class where they are put in a FIFO queue. The queue is consistently emptied while a Message handler is connected. After the message has been dequeued and handled, the connection is informed of the end of use of the buffer and can release it.

Other Changes:
```
- Removed the composite packet feature for UDP packets
- Removed write message queueing
+ NetworkConnections now protect their socket with a simple mutex for writing
- size prefixes for UDP packets
~ Naming convention changes  
```